### PR TITLE
Refactor operation rendering and unify output keys

### DIFF
--- a/packages/cletus/src/agents/chat-orchestrator.ts
+++ b/packages/cletus/src/agents/chat-orchestrator.ts
@@ -136,8 +136,8 @@ export async function runChatOrchestrator(
       const pending: Message = {
         role: 'assistant',
         name: chatMeta.assistant,
-        content: [{ type: 'text', content: '' }],
-        created: Date.now(),
+        content: [],
+        created: performance.now(),
         operations: [],
       };
 

--- a/packages/cletus/src/chat-ui.tsx
+++ b/packages/cletus/src/chat-ui.tsx
@@ -10,17 +10,16 @@ import { ModelSelector } from './components/ModelSelector';
 import { CompletionResult, OperationApprovalMenu } from './components/OperationApprovalMenu';
 import { ConfigFile } from './config';
 import type { AgentMode, ChatMeta, ChatMode, Message } from './schemas';
+import { getTotalTokens } from '@aits/core';
 // @ts-ignore
 import mic from 'mic';
 import { Writer } from 'wav';
 import { createChatAgent } from './agents/chat-agent';
 import { runChatOrchestrator } from './agents/chat-orchestrator';
-import { logger } from './logger';
 import { COLORS } from './constants';
 import { fileIsDirectory } from './helpers/files';
 import { useAdaptiveDebounce, useSyncedState } from './hooks';
-import { set } from 'zod';
-import { getTotalTokens } from '@aits/core';
+import { logger } from './logger';
 
 
 interface ChatUIProps {
@@ -179,7 +178,7 @@ export const ChatUI: React.FC<ChatUIProps> = ({ chat, config, messages, onExit, 
 
   // Convenience function to add system message
   const addSystemMessage = (content: string) => {
-    addMessage({ role: 'system', content: [{ type: 'text', content }], created: Date.now() });
+    addMessage({ role: 'system', content: [{ type: 'text', content }], created: performance.now() });
   };
 
   // Load messages from file on mount
@@ -923,7 +922,7 @@ After installation and the SoX executable is in the path, restart Cletus and try
       role: 'user',
       name: config.getData().user.name,
       content: [{ type: 'text', content: inputValue }],
-      created: Date.now(),
+      created: performance.now(),
     });
 
     // Reset history navigation
@@ -1010,11 +1009,11 @@ After installation and the SoX executable is in the path, restart Cletus and try
           <>
             <Static key={renderKey} items={visibleMessages}>
               {(msg: Message) => (
-                <MessageDisplay key={msg.created} message={msg} config={config} showInput={showInput} showOutput={showOutput}/>
+                <MessageDisplay key={`${renderKey}-${msg.created}`} message={msg} config={config} showInput={showInput} showOutput={showOutput}/>
               )}
             </Static>
             {lastMessage && (
-              <MessageDisplay key={lastMessage.created} message={lastMessage} config={config} showInput={showInput} showOutput={showOutput} />
+              <MessageDisplay key={`${renderKey}-${lastMessage.created}`} message={lastMessage} config={config} showInput={showInput} showOutput={showOutput} />
             )}
             {showPendingMessage && (
               <MessageDisplay message={pendingMessage} config={config} showInput={showInput} showOutput={showOutput} />

--- a/packages/cletus/src/chat.ts
+++ b/packages/cletus/src/chat.ts
@@ -33,7 +33,7 @@ export class ChatFile extends JsonFile<ChatMessages> {
     await this.save((chat) => {
       chat.messages.push({
         ...message,
-        created: Date.now(),
+        created: performance.now(),
       });
     });
   }

--- a/packages/cletus/src/common.ts
+++ b/packages/cletus/src/common.ts
@@ -59,40 +59,32 @@ export function abbreviate(text: string, maxLength: number, suffix: string = 'â€
  * - Objects: bullet list with hyphens, property values without JSON escaping
  * 
  * @param value - value to format
- * @param depth - current indentation depth (default 0)
+ * @param alreadyIndented - whether content should be indented/hyphenated
  * @returns formatted string
  */
-export function formatValue(value: any, depth: number = 0): string {
+export function formatValue(value: any, alreadyIndented: boolean = false): string {
   // Handle null/undefined
   if (value === null) {
-    return 'null';
+    return `null`;
   }
   if (value === undefined) {
-    return 'undefined';
+    return `undefined`;
   }
-  
-  // Calculate indentation for the next level
-  const indent = '  '.repeat(depth + 1);
+
+  const hyphenPrefix = alreadyIndented ? '' : '- ';
   
   // Arrays: list items with hyphens
   if (Array.isArray(value)) {
     if (value.length === 0) {
-      return '[]';
+      return `[]`;
     }
-    return value.map((item, i) => {
-      const formatted = formatValue(item, depth + 1);
-      // For simple values, show on same line
-      if (typeof item !== 'object' || item === null) {
-        return `- ${formatted}`;
-      }
-      // For objects, indent their properties
-      return `- ${formatted.split('\n').join('\n' + indent)}`;
-    }).join('\n');
+    return '\n' + value.map((item, i) => `${hyphenPrefix}${formatValue(item, true).split('\n').join('\n  ')}`).join('\n');
   }
   
   // Non-objects (primitives): use String(x)
   if (typeof value !== 'object') {
-    return String(value);
+    const x = String(value);
+    return !alreadyIndented && x.includes('\n') ? `\n  ${x.split('\n').join('\n  ')}` : x;
   }
   
   // Objects: bullet list with hyphens
@@ -101,15 +93,7 @@ export function formatValue(value: any, depth: number = 0): string {
     return '{}';
   }
   
-  return entries.map(([key, val]) => {
-    const formatted = formatValue(val, depth + 1);
-    // For simple values, show on same line
-    if (typeof val !== 'object' || val === null) {
-      return `- ${key}: ${formatted}`;
-    }
-    // For complex values (objects/arrays), show on multiple lines
-    return `- ${key}:\n${indent}${formatted.split('\n').join('\n' + indent)}`;
-  }).join('\n');
+  return entries.map(([key, val]) => `${hyphenPrefix}${key}: ${formatValue(val).split('\n').join('\n  ')}`).join('\n');
 }
 
 /**

--- a/packages/cletus/src/helpers/render.tsx
+++ b/packages/cletus/src/helpers/render.tsx
@@ -51,9 +51,9 @@ export function getElapsedTime(op: Operation): string {
 /**
  * Get summary text for an operation
  */
-export function getSummary(
-  op: Operation,
-  getSummaryText?: (op: Operation) => string | null
+export function getSummary<TOperation extends Operation>(
+  op: TOperation,
+  getSummaryText?: (op: TOperation) => string | null
 ): string {
   if (op.error) {
     return op.error;
@@ -84,10 +84,10 @@ export function getSummary(
  * @param showInput - Whether to show detailed input
  * @param showOutput - Whether to show detailed output
  */
-export function renderOperation(
-  op: Operation,
+export function renderOperation<TOperation extends Operation>(
+  op: TOperation,
   operationLabel: string,
-  getSummaryText?: (op: Operation) => string | null,
+  getSummaryText?: (op: TOperation) => string | null,
   showInput?: boolean,
   showOutput?: boolean
 ): React.ReactNode {
@@ -123,13 +123,13 @@ export function renderOperation(
         </>
       )}
       
-      {showOutput && op.output && (
+      {showOutput && (op.analysis || op.output) && (
         <>
           <Box marginLeft={2} marginTop={1}>
-            <Text bold dimColor>Output:</Text>
+            <Text bold dimColor>{op.output ? 'Output' : 'Analysis'}:</Text>
           </Box>
           <Box marginLeft={4} flexDirection="column">
-            {formatValue(op.output)}
+            {formatValue(op.output || op.analysis)}
           </Box>
         </>
       )}

--- a/packages/cletus/src/operations/architect.tsx
+++ b/packages/cletus/src/operations/architect.tsx
@@ -48,6 +48,7 @@ export const type_info = operationOf<
   do: async (input, { config }) => {
     const types = config.getData().types;
     const type = types.find((t) => t.name === input.name);
+    
     return { type: type || null };
   },
   render: (op, config, showInput, showOutput) => renderOperation(
@@ -60,7 +61,8 @@ export const type_info = operationOf<
         return `Type not found`;
       }
       return null;
-    }
+    },
+    showInput, showOutput
   ),
 });
 
@@ -68,7 +70,8 @@ type TypeUpdate = { name: string; update: { friendlyName?: string; description?:
 
 export const type_update = operationOf<
   TypeUpdate,
-  { name: string; updated: boolean }
+  { name: string; updated: boolean },
+  { validate: (input: TypeUpdate, config: ConfigFile) => string; fieldify(input: TypeUpdate, fields: TypeField[]): TypeField[] }
 >({
   mode: 'update',
   signature: 'type_update(name: string, update...)',
@@ -225,13 +228,15 @@ export const type_update = operationOf<
   render: (op, config, showInput, showOutput) => renderOperation(
     op,
     `${formatName(op.input.name)}Update(${Object.keys(op.input.update).join(', ')})`,
-    (op) => op.output?.updated ? 'Updated type successfully' : null
-  , showInput, showOutput),
+    (op) => op.output?.updated ? 'Updated type successfully' : null,
+    showInput, showOutput
+  ),
 });
 
 export const type_create = operationOf<
   TypeDefinition,
-  { type: TypeDefinition; created: boolean }
+  { type: TypeDefinition; created: boolean },
+  { validate: (input: TypeDefinition, config: ConfigFile) => string; }
 >({
   mode: 'create',
   signature: 'type_create(type: TypeDefinition)',
@@ -301,7 +306,8 @@ export const type_create = operationOf<
   },
   render: (op, config, showInput, showOutput) => renderOperation(
     op,
-    `${formatName(op.input.name)}Create(${op.input.fields.map(f => f.friendlyName).join(', ')})`,
-    (op) => op.output?.created ? `Created type: ${op.output.type.friendlyName}` : null
-  , showInput, showOutput),
+    `${formatName(op.input.name)}Create(fields: [${op.input.fields.map(f => f.friendlyName).join(', ')}])`,
+    (op) => op.output?.created ? `Created type: ${op.output.type.friendlyName}` : null,
+    showInput, showOutput
+  ),
 });

--- a/packages/cletus/src/operations/internet.tsx
+++ b/packages/cletus/src/operations/internet.tsx
@@ -62,8 +62,9 @@ export const web_search = operationOf<
         return `Found ${op.output.results.length} result${op.output.results.length !== 1 ? 's' : ''}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 // ============================================================================
@@ -223,7 +224,8 @@ export const web_get_page = operationOf<
         return parts.join(', ');
       }
       return null;
-    }
+    },
+    showInput, showOutput
   ),
 });
 
@@ -342,6 +344,7 @@ export const web_api_call = operationOf<
         return `${op.output.status} ${op.output.statusText} (${op.output.body.length} bytes)`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });

--- a/packages/cletus/src/operations/librarian.tsx
+++ b/packages/cletus/src/operations/librarian.tsx
@@ -51,8 +51,9 @@ export const knowledge_search = operationOf<
         return `Found ${count} result${count !== 1 ? 's' : ''}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const knowledge_sources = operationOf<{}, { sources: string[] }>({
@@ -90,8 +91,9 @@ export const knowledge_sources = operationOf<{}, { sources: string[] }>({
         return `Listed ${count} source${count !== 1 ? 's' : ''}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const knowledge_add = operationOf<
@@ -135,8 +137,9 @@ export const knowledge_add = operationOf<
         return `Added: "${abbreviate(op.input.text, 50)}"`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const knowledge_delete = operationOf<
@@ -226,6 +229,7 @@ export const knowledge_delete = operationOf<
         return `Deleted ${op.output.deletedCount} entr${op.output.deletedCount !== 1 ? 'ies' : 'y'}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });

--- a/packages/cletus/src/operations/planner.tsx
+++ b/packages/cletus/src/operations/planner.tsx
@@ -34,8 +34,9 @@ export const todos_clear = operationOf<{}, { cleared: boolean }>({
         return 'All todos cleared';
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const todos_list = operationOf<{}, { todos: TodoItem[] }>({
@@ -100,8 +101,9 @@ export const todos_add = operationOf<{ name: string }, { id: string; name: strin
         return `Added: "${op.output.name}"`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const todos_done = operationOf<{ id: string }, { id: string; done: boolean }>({
@@ -151,8 +153,9 @@ export const todos_done = operationOf<{ id: string }, { id: string; done: boolea
         return 'Marked todo as done';
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const todos_get = operationOf<{ id: string }, { todo: TodoItem | null }>({
@@ -179,8 +182,9 @@ export const todos_get = operationOf<{ id: string }, { todo: TodoItem | null }>(
         return op.output.todo ? `Found: "${op.output.todo.name}"` : 'Todo not found';
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const todos_remove = operationOf<{ id: string }, { id: string; removed: boolean }>({
@@ -222,8 +226,9 @@ export const todos_remove = operationOf<{ id: string }, { id: string; removed: b
         return 'Removed todo';
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const todos_replace = operationOf<{ todos: TodoItem[] }, { count: number }>({
@@ -258,6 +263,7 @@ export const todos_replace = operationOf<{ todos: TodoItem[] }, { count: number 
         return `Replaced with ${op.output.count} todo${op.output.count !== 1 ? 's' : ''}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });

--- a/packages/cletus/src/operations/secretary.tsx
+++ b/packages/cletus/src/operations/secretary.tsx
@@ -40,11 +40,12 @@ export const assistant_switch = operationOf<
     `AssistantSwitch("${op.input.name}")`,
     (op) => {
       if (op.output) {
-        return `Switched to assistant: ${op.output.assistant}`;
+        return `Switched to assistant: ${op.input.name}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const assistant_update = operationOf<
@@ -90,11 +91,12 @@ export const assistant_update = operationOf<
     `AssistantUpdate("${op.input.name}")`,
     (op) => {
       if (op.output) {
-        return `Updated assistant: ${op.output.name}`;
+        return `Updated assistant: ${op.input.name}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const assistant_add = operationOf<
@@ -136,11 +138,12 @@ export const assistant_add = operationOf<
     `AssistantAdd("${op.input.name}")`,
     (op) => {
       if (op.output) {
-        return `Created assistant: ${op.output.name}`;
+        return `Created assistant: ${op.input.name}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const memory_list = operationOf<
@@ -173,8 +176,9 @@ export const memory_list = operationOf<
         return `${count} memor${count !== 1 ? 'ies' : 'y'}`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });
 
 export const memory_update = operationOf<
@@ -199,9 +203,10 @@ export const memory_update = operationOf<
     `MemoryUpdate("${abbreviate(op.input.content, 30)}")`,
     (op) => {
       if (op.output) {
-        return `Added: "${abbreviate(op.output.content, 50)}"`;
+        return `Added: "${abbreviate(op.input.content, 50)}"`;
       }
       return null;
-    }
-  , showInput, showOutput),
+    },
+    showInput, showOutput
+  ),
 });

--- a/packages/cletus/src/operations/types.ts
+++ b/packages/cletus/src/operations/types.ts
@@ -119,7 +119,7 @@ export type OperationDefinition<TInput, TOutput> = {
 export type OperationDefinitionFor<K extends OperationKind> = OperationDefinition<OperationInputFor<K>, OperationOutputFor<K>>;
 
 // Helper to define an operation
-export function operationOf<TInput, TOutput>(def: Plus<OperationDefinition<TInput, TOutput>>): OperationDefinition<TInput, TOutput> {
+export function operationOf<TInput, TOutput, TExtension extends object = {}>(def: OperationDefinition<TInput, TOutput> & TExtension): OperationDefinition<TInput, TOutput> {
   return def;
 }
 

--- a/packages/cletus/src/tools/artist.ts
+++ b/packages/cletus/src/tools/artist.ts
@@ -26,10 +26,10 @@ Example: Generate a landscape image:
     instructions: `Use this to modify an existing image. Provide a file path (relative or absolute path or[filename](filepath)) and a description of the edit. The edited image will be saved as a new file.
 
 Example: Add a sunset effect to an image:
-{ "prompt": "Add warm sunset colors and lighting", "imagePath": "images/photo.jpg" }`,
+{ "prompt": "Add warm sunset colors and lighting", "path": "images/photo.jpg" }`,
     schema: z.object({
       prompt: z.string().describe('Description of how to edit the image'),
-      imagePath: z.string().describe('Path to the image to edit (relative path or absolute path or [filename](filepath) URL)'),
+      path: z.string().describe('Path to the image to edit (relative path or absolute path or [filename](filepath) URL)'),
     }),
     call: async (input, _, ctx) => ctx.ops.handle({ type: 'image_edit', input }, ctx),
   });
@@ -40,10 +40,10 @@ Example: Add a sunset effect to an image:
     instructions: `Use this to understand what's in images or answer specific questions about them. Can analyze multiple images together for comparison.
 
 Example: Compare two designs:
-{ "prompt": "What are the main differences between these two UI designs?", "imagePaths": ["designs/v1.png", "designs/v2.png"] }`,
+{ "prompt": "What are the main differences between these two UI designs?", "paths": ["designs/v1.png", "designs/v2.png"] }`,
     schema: z.object({
       prompt: z.string().describe('Question or analysis request about the images'),
-      imagePaths: z.array(z.string()).describe('Paths to images to analyze (relative paths or absolute file or [filename](filepath))'),
+      paths: z.array(z.string()).describe('Paths to images to analyze (relative paths or absolute file or [filename](filepath))'),
       maxCharacters: z.number().optional().default(2084).describe('Maximum response length (maxCharacters/4 = maxTokens, default: 2084)'),
     }),
     call: async (input, _, ctx) => ctx.ops.handle({ type: 'image_analyze', input }, ctx),
@@ -55,9 +55,9 @@ Example: Compare two designs:
     instructions: `Use this to generate a comprehensive description of an image's contents without a specific question.
 
 Example: Describe a screenshot:
-{ "imagePath": "screenshots/dashboard.png" }`,
+{ "path": "screenshots/dashboard.png" }`,
     schema: z.object({
-      imagePath: z.string().describe('Path to the image to describe (relative path or absolute path or [filename](filepath))'),
+      path: z.string().describe('Path to the image to describe (relative path or absolute path or [filename](filepath))'),
     }),
     call: async (input, _, ctx) => ctx.ops.handle({ type: 'image_describe', input }, ctx),
   });


### PR DESCRIPTION
Refactored operation rendering functions to use consistent argument order and generic types. Standardized output keys for image operations (e.g., 'path' to 'links', 'imagePath' to 'path') and updated related schemas and tools. Improved commit message and output formatting for operations, fixed pluralization, and replaced Date.now() with performance.now() for message timestamps. Minor code cleanups and improved type safety throughout.